### PR TITLE
don't enforce roles types

### DIFF
--- a/include/couch_js_functions.hrl
+++ b/include/couch_js_functions.hrl
@@ -39,12 +39,6 @@
             throw({forbidden: 'doc.roles must be an array'});
         }
 
-        for (var idx = 0; idx < newDoc.roles.length; idx++) {
-            if (typeof newDoc.roles[idx] !== 'string') {
-                throw({forbidden: 'doc.roles can only contain strings'});
-            }
-        }
-
         if (newDoc._id !== ('org.couchdb.user:' + newDoc.name)) {
             throw({
                 forbidden: 'Doc ID must be of the form org.couchdb.user:name'

--- a/src/couch_db.erl
+++ b/src/couch_db.erl
@@ -397,10 +397,8 @@ validate_names_and_roles({Props}) when is_list(Props) ->
     _ -> throw("names must be a JSON list of strings")
     end,
     case couch_util:get_value(<<"roles">>,Props,[]) of
-    Rs when is_list(Rs) ->
-        [throw("roles must be a JSON list of strings") ||R <- Rs, not is_binary(R)],
-        Rs;
-    _ -> throw("roles must be a JSON list of strings")
+    Rs when is_list(Rs) -> Rs;
+    _ -> throw("roles must be a JSON list.")
     end,
     ok.
 


### PR DESCRIPTION
Some users use complex roles instead of simple string. 

Reverse the change done in couch long time ago in [COUCHDB-1675](https://issues.apache.org/jira/browse/COUCHDB-1675). Instead of forcing all roles to be string we remove this validation inside the security doc. Admin and User validation is still working after that change.
